### PR TITLE
Folcon/repro issue 5

### DIFF
--- a/src/lambdaisland/cljbox2d.cljc
+++ b/src/lambdaisland/cljbox2d.cljc
@@ -104,12 +104,14 @@
   (awake? [_])
   (linear-velocity [_])
   (angular-velocity [_])
-  (world-center [_]))
+  (world-center [_])
+  (zoom [_]))
 
 (defprotocol IOperations
   (move-to! [_ v])
   (move-by! [_ v])
-  (zoom*! [_ f])
+  (zoom! [_ f])
+  (zoom+! [_ f])
   (ctl1! [entity k v] "Generically control properties")
   (alter-user-data*! [entity f args])
   (apply-force! [_ force] [_ force point])
@@ -835,11 +837,11 @@
   (doseq [[k v] (partition 2 kvs)]
     (ctl1! entity k v)))
 
-(defn zoom!
+(defn zoom-by!
   ([amount]
-   (zoom*! *camera* amount))
+   (zoom+! *camera* amount))
   ([camera amount]
-   (zoom*! camera amount)))
+   (zoom+! camera amount)))
 
 (defn pan!
   ([x y]
@@ -974,6 +976,8 @@
     (camera/center c))
   (transform [c]
     (.-transform c))
+  (zoom [c]
+    (camera/zoom c))
 
   Joint
   (user-data [j]
@@ -1040,10 +1044,10 @@
     (.set ^Vec2 (.-center camera) (math/vec-add (.-center camera)
                                                 (as-vec2 offset)))
     camera)
-  (zoom*! [camera amount]
-    (.set ^Mat22 (.-transform camera)
-          (math/mat-add (.-transform camera)
-                        (math/scale-transform amount))))
+  (zoom! [camera amount]
+    (camera/set-scale! camera amount))
+  (zoom+! [camera amount]
+    (zoom! camera (math/mat-add (zoom camera) (math/scale-transform amount))))
 
   Fixture
   (alter-user-data*! [fixt f args]

--- a/src/lambdaisland/cljbox2d/camera.cljc
+++ b/src/lambdaisland/cljbox2d/camera.cljc
@@ -8,7 +8,8 @@
 (defprotocol ICamera
   (center [cam])
   (world->screen [cam vec])
-  (screen->world [cam vec]))
+  (screen->world [cam vec])
+  (zoom [cam]))
 
 (defrecord Camera [^Mat22 transform ^Vec2 center ^Vec2 extents]
   ICamera
@@ -17,7 +18,9 @@
   (world->screen [_ world]
     (math/vec-add (math/mat-mul transform (math/vec-sub world center)) extents))
   (screen->world [_ screen]
-    (math/vec-add (math/mat-mul (math/mat-invert transform) (math/vec-sub screen extents)) center)))
+    (math/vec-add (math/mat-mul (math/mat-invert transform) (math/vec-sub screen extents)) center))
+  (zoom [_]
+    transform))
 
 (defn camera [x y scale]
   (let [r (math/scale-transform scale)
@@ -37,5 +40,7 @@
   camera)
 
 (defn set-scale! [camera scale]
-  (.set (:transform camera) (math/scale-transform scale))
+  (case (type scale)
+    Mat22 (.set (:transform camera) scale)
+    (.set (:transform camera) (math/scale-transform scale)))
   camera)

--- a/src/lambdaisland/cljbox2d/demo/clojure2d/repro.clj
+++ b/src/lambdaisland/cljbox2d/demo/clojure2d/repro.clj
@@ -1,0 +1,14 @@
+(ns lambdaisland.cljbox2d.demo.clojure2d.repro
+  (:require
+    [lambdaisland.cljbox2d :as b]
+    [lambdaisland.cljbox2d :as b]))
+
+
+
+(def world (b/world 0 0))
+
+(b/add-body
+  world
+  {:position [0 0]
+   :type :dynamic
+   :fixtures [{:shape [:circle [20 20] 20]}]})


### PR DESCRIPTION
Creating PR for changes against issue #4.

Changes so far:
- Have zoom return the Mat22 transform instead of the zoom-level scalar.
- If you feed zoom! a transform or a scalar it correctly sets the absolute zoom value.
- zoom+! is provides zoom addition at `IOperations` level.
- zoom-by! provides original zoom! functionality.